### PR TITLE
Add contact form and dashboard stubs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,27 @@ import { FAQSection } from './components/home/FAQSection'
 import { ContactSection } from './components/home/ContactSection'
 import { WhatsAppButton } from './components/widgets/WhatsAppButton'
 import { FloatingCTA } from './components/widgets/FloatingCTA'
+import { ClientDashboard } from './pages/dashboard/ClientDashboard'
+import { FreelancerDashboard } from './pages/dashboard/FreelancerDashboard'
+import { useAuth } from './hooks/useAuth'
 
 function App() {
+  const { profile } = useAuth()
+  const path = window.location.pathname
+
+  if (path.startsWith('/dashboard')) {
+    if (!profile) {
+      return <div className="p-6">Veuillez vous connecter.</div>
+    }
+    if (path === '/dashboard/client' && profile.user_type === 'client') {
+      return <ClientDashboard />
+    }
+    if (path === '/dashboard/freelancer' && profile.user_type === 'freelancer') {
+      return <FreelancerDashboard />
+    }
+    return <div className="p-6">Accès non autorisé.</div>
+  }
+
   return (
     <div className="min-h-screen bg-white">
       <Header />

--- a/src/components/home/ContactSection.tsx
+++ b/src/components/home/ContactSection.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
 import { motion } from 'framer-motion'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '../ui/Button'
+import { submitContactRequest } from '../../lib/supabase'
+import { toast } from 'react-hot-toast'
 
 export const ContactSection: React.FC = () => {
   return (
@@ -14,8 +20,77 @@ export const ContactSection: React.FC = () => {
         >
           Contact
         </motion.h2>
-        <p className="text-center text-gray-600">Section à compléter.</p>
+        <ContactForm />
       </div>
     </section>
+  )
+}
+
+const schema = z.object({
+  name: z.string().min(1, 'Nom requis'),
+  email: z.string().email('Email invalide'),
+  message: z.string().min(1, 'Message requis'),
+  project: z.string().min(1, 'Détails requis'),
+})
+
+type FormValues = z.infer<typeof schema>
+
+const ContactForm: React.FC = () => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = async (data: FormValues) => {
+    const { error } = await submitContactRequest(data)
+    if (error) {
+      toast.error('Erreur lors de l\'envoi')
+    } else {
+      toast.success('Demande envoyée !')
+      reset()
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="max-w-xl mx-auto space-y-4">
+      <input
+        className="w-full border p-3 rounded"
+        placeholder="Nom"
+        {...register('name')}
+      />
+      {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+
+      <input
+        className="w-full border p-3 rounded"
+        placeholder="Email"
+        type="email"
+        {...register('email')}
+      />
+      {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+
+      <textarea
+        className="w-full border p-3 rounded"
+        placeholder="Message"
+        rows={3}
+        {...register('message')}
+      />
+      {errors.message && <p className="text-red-500 text-sm">{errors.message.message}</p>}
+
+      <textarea
+        className="w-full border p-3 rounded"
+        placeholder="Détails du projet"
+        rows={3}
+        {...register('project')}
+      />
+      {errors.project && <p className="text-red-500 text-sm">{errors.project.message}</p>}
+
+      <div className="text-center">
+        <Button type="submit" loading={isSubmitting}>
+          Envoyer
+        </Button>
+      </div>
+    </form>
   )
 }

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { Play, Star, ArrowRight } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { scrollToContact } from '../../lib/navigation'
 
 export const Hero: React.FC = () => {
   return (
@@ -52,7 +53,7 @@ export const Hero: React.FC = () => {
 
             {/* CTAs */}
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-              <Button size="lg" className="group">
+              <Button size="lg" className="group" onClick={scrollToContact}>
                 Trouver un freelance
                 <ArrowRight className="w-5 h-5 ml-2 group-hover:translate-x-1 transition-transform" />
               </Button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Menu, X, User, LogOut } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { useAuth } from '../../hooks/useAuth'
+import { scrollToContact } from '../../lib/navigation'
 
 export const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -58,6 +59,12 @@ export const Header: React.FC = () => {
           <div className="hidden md:flex items-center space-x-4">
             {profile ? (
               <div className="flex items-center space-x-4">
+                <a
+                  href={profile.user_type === 'client' ? '/dashboard/client' : '/dashboard/freelancer'}
+                  className="text-sm text-navy-700 hover:text-gold-600 transition-colors"
+                >
+                  Dashboard
+                </a>
                 <div className="flex items-center space-x-2">
                   <User className="w-5 h-5 text-navy-700" />
                   <span className="text-sm text-navy-700">{profile.full_name || profile.email}</span>
@@ -83,7 +90,7 @@ export const Header: React.FC = () => {
                 >
                   Se connecter
                 </Button>
-                <Button size="sm">
+                <Button size="sm" onClick={scrollToContact}>
                   Trouver un freelance
                 </Button>
               </>
@@ -126,6 +133,13 @@ export const Header: React.FC = () => {
                 {profile ? (
                   <div className="space-y-2">
                     <p className="text-sm font-medium text-navy-700">{profile.full_name || profile.email}</p>
+                    <a
+                      href={profile.user_type === 'client' ? '/dashboard/client' : '/dashboard/freelancer'}
+                      className="block text-sm text-navy-700 hover:text-gold-600 transition-colors"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Dashboard
+                    </a>
                     <Button variant="outline" size="sm" onClick={signOut} className="w-full">
                       Se déconnecter
                     </Button>
@@ -140,7 +154,14 @@ export const Header: React.FC = () => {
                     >
                       Se connecter
                     </Button>
-                    <Button size="sm" className="w-full">
+                    <Button
+                      size="sm"
+                      className="w-full"
+                      onClick={() => {
+                        scrollToContact()
+                        setIsMenuOpen(false)
+                      }}
+                    >
                       Trouver un freelance
                     </Button>
                   </>

--- a/src/components/widgets/FloatingCTA.tsx
+++ b/src/components/widgets/FloatingCTA.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X, ArrowRight } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { scrollToContact } from '../../lib/navigation'
 
 export const FloatingCTA: React.FC = () => {
   const [isVisible, setIsVisible] = useState(false)
@@ -47,7 +48,7 @@ export const FloatingCTA: React.FC = () => {
               Trouvez le freelance parfait en moins de 24h
             </p>
             
-            <Button size="sm" className="w-full group">
+            <Button size="sm" className="w-full group" onClick={scrollToContact}>
               Démarrer maintenant
               <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform" />
             </Button>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,6 @@
+export const scrollToContact = () => {
+  const el = document.getElementById('contact');
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth' });
+  }
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,3 +44,20 @@ export const fetchTestimonials = async (): Promise<Testimonial[]> => {
   if (error) throw error
   return data as Testimonial[]
 }
+
+export const submitContactRequest = async (
+  request: { name: string; email: string; message: string; project: string }
+) => {
+  if (isDemoMode) {
+    return { error: null }
+  }
+
+  const { error } = await supabase.from('contact_requests').insert({
+    name: request.name,
+    email: request.email,
+    message: request.message,
+    project_details: request.project,
+  })
+
+  return { error }
+}

--- a/src/pages/dashboard/ClientDashboard.tsx
+++ b/src/pages/dashboard/ClientDashboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useAuth } from '../../hooks/useAuth'
+
+export const ClientDashboard: React.FC = () => {
+  const { profile } = useAuth()
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Tableau de bord Client</h1>
+      <p className="text-gray-700">Bienvenue {profile?.full_name || profile?.email}</p>
+    </div>
+  )
+}

--- a/src/pages/dashboard/FreelancerDashboard.tsx
+++ b/src/pages/dashboard/FreelancerDashboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useAuth } from '../../hooks/useAuth'
+
+export const FreelancerDashboard: React.FC = () => {
+  const { profile } = useAuth()
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Tableau de bord Freelance</h1>
+      <p className="text-gray-700">Bienvenue {profile?.full_name || profile?.email}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable scroll helper and connect CTA buttons
- implement contact form with Supabase submission
- scaffold client and freelancer dashboards with simple routing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a1f9d090748325813a781e69463435