### PR TITLE
Add dark mode, Stripe checkout, animations and dashboard widgets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,11 +11,20 @@ import { WhatsAppButton } from './components/widgets/WhatsAppButton'
 import { FloatingCTA } from './components/widgets/FloatingCTA'
 import { ClientDashboard } from './pages/dashboard/ClientDashboard'
 import { FreelancerDashboard } from './pages/dashboard/FreelancerDashboard'
+import { CheckoutSuccess } from './pages/checkout/Success'
+import { CheckoutCancel } from './pages/checkout/Cancel'
 import { useAuth } from './hooks/useAuth'
 
 function App() {
   const { profile } = useAuth()
   const path = window.location.pathname
+
+  if (path === '/checkout/success') {
+    return <CheckoutSuccess />
+  }
+  if (path === '/checkout/cancel') {
+    return <CheckoutCancel />
+  }
 
   if (path.startsWith('/dashboard')) {
     if (!profile) {
@@ -31,7 +40,7 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white dark:bg-navy-900 dark:text-gray-100">
       <Header />
       <main>
         <Hero />

--- a/src/components/home/ContactSection.tsx
+++ b/src/components/home/ContactSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -9,10 +9,10 @@ import { toast } from 'react-hot-toast'
 
 export const ContactSection: React.FC = () => {
   return (
-    <section id="contact" className="py-20 bg-white">
+    <section id="contact" className="py-20 bg-white dark:bg-navy-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <motion.h2
-          className="text-3xl md:text-4xl font-bold text-navy-900 mb-6 text-center"
+          className="text-3xl md:text-4xl font-bold text-navy-900 dark:text-white mb-6 text-center"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -43,6 +43,8 @@ const ContactForm: React.FC = () => {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({ resolver: zodResolver(schema) })
 
+  const shouldReduceMotion = useReducedMotion()
+
   const onSubmit = async (data: FormValues) => {
     const { error } = await submitContactRequest(data)
     if (error) {
@@ -55,42 +57,76 @@ const ContactForm: React.FC = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="max-w-xl mx-auto space-y-4">
-      <input
-        className="w-full border p-3 rounded"
-        placeholder="Nom"
-        {...register('name')}
-      />
-      {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+      <motion.div
+        initial={shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        viewport={{ once: true }}
+      >
+        <input
+          className="w-full border p-3 rounded bg-white dark:bg-navy-700 dark:border-navy-600 dark:text-gray-100"
+          placeholder="Nom"
+          {...register('name')}
+        />
+        {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+      </motion.div>
 
-      <input
-        className="w-full border p-3 rounded"
-        placeholder="Email"
-        type="email"
-        {...register('email')}
-      />
-      {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      <motion.div
+        initial={shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.1 }}
+        viewport={{ once: true }}
+      >
+        <input
+          className="w-full border p-3 rounded bg-white dark:bg-navy-700 dark:border-navy-600 dark:text-gray-100"
+          placeholder="Email"
+          type="email"
+          {...register('email')}
+        />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </motion.div>
 
-      <textarea
-        className="w-full border p-3 rounded"
-        placeholder="Message"
-        rows={3}
-        {...register('message')}
-      />
-      {errors.message && <p className="text-red-500 text-sm">{errors.message.message}</p>}
+      <motion.div
+        initial={shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.2 }}
+        viewport={{ once: true }}
+      >
+        <textarea
+          className="w-full border p-3 rounded bg-white dark:bg-navy-700 dark:border-navy-600 dark:text-gray-100"
+          placeholder="Message"
+          rows={3}
+          {...register('message')}
+        />
+        {errors.message && <p className="text-red-500 text-sm">{errors.message.message}</p>}
+      </motion.div>
 
-      <textarea
-        className="w-full border p-3 rounded"
-        placeholder="Détails du projet"
-        rows={3}
-        {...register('project')}
-      />
-      {errors.project && <p className="text-red-500 text-sm">{errors.project.message}</p>}
+      <motion.div
+        initial={shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        viewport={{ once: true }}
+      >
+        <textarea
+          className="w-full border p-3 rounded bg-white dark:bg-navy-700 dark:border-navy-600 dark:text-gray-100"
+          placeholder="Détails du projet"
+          rows={3}
+          {...register('project')}
+        />
+        {errors.project && <p className="text-red-500 text-sm">{errors.project.message}</p>}
+      </motion.div>
 
-      <div className="text-center">
+      <motion.div
+        className="text-center"
+        initial={shouldReduceMotion ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+        viewport={{ once: true }}
+      >
         <Button type="submit" loading={isSubmitting}>
           Envoyer
         </Button>
-      </div>
+      </motion.div>
     </form>
   )
 }

--- a/src/components/home/FAQSection.tsx
+++ b/src/components/home/FAQSection.tsx
@@ -1,12 +1,21 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
+
+const faqs = [
+  { q: "Comment fonctionne la plateforme ?", a: "Nous vous connectons aux meilleurs freelances selon vos besoins." },
+  { q: "Quels sont les délais moyens ?", a: "La plupart des projets sont livrés en moins de 72h." },
+  { q: "Puis-je annuler à tout moment ?", a: "Oui, les abonnements sont sans engagement." }
+]
 
 export const FAQSection: React.FC = () => {
+  const [open, setOpen] = useState<number | null>(null)
+
   return (
-    <section id="faq" className="py-20 bg-primary-50">
+    <section id="faq" className="py-20 bg-primary-50 dark:bg-navy-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <motion.h2
-          className="text-3xl md:text-4xl font-bold text-navy-900 mb-6 text-center"
+          className="text-3xl md:text-4xl font-bold text-navy-900 dark:text-white mb-6 text-center"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -14,7 +23,37 @@ export const FAQSection: React.FC = () => {
         >
           FAQ
         </motion.h2>
-        <p className="text-center text-gray-600">Section à compléter.</p>
+        <div className="max-w-3xl mx-auto">
+          {faqs.map((item, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              viewport={{ once: true }}
+              className="border-b border-gray-200 dark:border-navy-600 py-4"
+            >
+              <button
+                className="w-full flex justify-between items-center text-left"
+                onClick={() => setOpen(open === i ? null : i)}
+              >
+                <span className="font-medium text-navy-900 dark:text-white">{item.q}</span>
+                <ChevronDown
+                  className={`w-5 h-5 text-navy-900 dark:text-white transition-transform ${open === i ? 'rotate-180' : ''}`}
+                />
+              </button>
+              {open === i && (
+                <motion.p
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  className="mt-2 text-gray-600 dark:text-gray-300"
+                >
+                  {item.a}
+                </motion.p>
+              )}
+            </motion.div>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -8,7 +8,7 @@ export const Hero: React.FC = () => {
   return (
     <section id="home" className="relative min-h-screen flex items-center justify-center overflow-hidden">
       {/* Background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-primary-100 via-white to-gold-50" />
+      <div className="absolute inset-0 bg-gradient-to-br from-primary-100 via-white to-gold-50 dark:from-navy-800 dark:via-navy-900 dark:to-navy-950" />
       
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
@@ -37,7 +37,7 @@ export const Hero: React.FC = () => {
             </motion.div>
 
             {/* Title */}
-            <h1 className="text-4xl md:text-6xl font-bold text-navy-900 mb-6">
+            <h1 className="text-4xl md:text-6xl font-bold text-navy-900 dark:text-white mb-6">
               Ton{' '}
               <span className="text-transparent bg-clip-text bg-gradient-to-r from-gold-500 to-gold-600">
                 contenu
@@ -46,7 +46,7 @@ export const Hero: React.FC = () => {
             </h1>
 
             {/* Subtitle */}
-            <p className="text-xl text-gray-600 mb-8 max-w-2xl">
+            <p className="text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-2xl">
               Connectez-vous aux meilleurs freelances créatifs en moins de 24h. 
               De l'idée à la livraison, nous gérons tout pour vous.
             </p>
@@ -96,8 +96,8 @@ export const Hero: React.FC = () => {
                     <span className="text-green-600 font-bold">✓</span>
                   </div>
                   <div>
-                    <p className="font-semibold text-navy-900">Livré en 48h</p>
-                    <p className="text-sm text-gray-600">Projet terminé</p>
+                    <p className="font-semibold text-navy-900 dark:text-white">Livré en 48h</p>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">Projet terminé</p>
                   </div>
                 </div>
               </motion.div>

--- a/src/components/home/HowItWorksSection.tsx
+++ b/src/components/home/HowItWorksSection.tsx
@@ -3,10 +3,10 @@ import { motion } from 'framer-motion'
 
 export const HowItWorksSection: React.FC = () => {
   return (
-    <section id="how-it-works" className="py-20 bg-primary-50">
+    <section id="how-it-works" className="py-20 bg-primary-50 dark:bg-navy-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <motion.h2
-          className="text-3xl md:text-4xl font-bold text-navy-900 mb-6 text-center"
+          className="text-3xl md:text-4xl font-bold text-navy-900 dark:text-white mb-6 text-center"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -14,7 +14,7 @@ export const HowItWorksSection: React.FC = () => {
         >
           Comment ça marche
         </motion.h2>
-        <p className="text-center text-gray-600">Section à compléter.</p>
+        <p className="text-center text-gray-600 dark:text-gray-300">Section à compléter.</p>
       </div>
     </section>
   )

--- a/src/components/home/PortfolioSection.tsx
+++ b/src/components/home/PortfolioSection.tsx
@@ -1,12 +1,18 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 
+const projects = [
+  { title: 'Campagne Réseaux Sociaux', image: 'https://images.pexels.com/photos/1181675/pexels-photo-1181675.jpeg?auto=compress&cs=tinysrgb&w=800' },
+  { title: 'Vidéo Promotionnelle', image: 'https://images.pexels.com/photos/572056/pexels-photo-572056.jpeg?auto=compress&cs=tinysrgb&w=800' },
+  { title: 'Design de Marque', image: 'https://images.pexels.com/photos/3184465/pexels-photo-3184465.jpeg?auto=compress&cs=tinysrgb&w=800' }
+]
+
 export const PortfolioSection: React.FC = () => {
   return (
-    <section id="portfolio" className="py-20 bg-white">
+    <section id="portfolio" className="py-20 bg-white dark:bg-navy-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <motion.h2
-          className="text-3xl md:text-4xl font-bold text-navy-900 mb-6 text-center"
+          className="text-3xl md:text-4xl font-bold text-navy-900 dark:text-white mb-6 text-center"
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
@@ -14,7 +20,23 @@ export const PortfolioSection: React.FC = () => {
         >
           Portfolio
         </motion.h2>
-        <p className="text-center text-gray-600">Section à compléter.</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {projects.map((p, i) => (
+            <motion.div
+              key={p.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+              viewport={{ once: true }}
+              className="rounded-xl overflow-hidden shadow-lg"
+            >
+              <img src={p.image} alt={p.title} className="w-full h-56 object-cover" />
+              <div className="p-4 bg-white dark:bg-navy-700">
+                <h3 className="text-lg font-semibold text-navy-900 dark:text-white">{p.title}</h3>
+              </div>
+            </motion.div>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/src/components/home/PricingSection.tsx
+++ b/src/components/home/PricingSection.tsx
@@ -3,11 +3,10 @@ import { motion } from 'framer-motion'
 import { Check, Crown, Star, Zap } from 'lucide-react'
 import { Card } from '../ui/Card'
 import { Button } from '../ui/Button'
-import { subscriptionPlans } from '../../lib/stripe'
+import { subscriptionPlans, redirectToCheckout } from '../../lib/stripe'
 
-const subscribe = (planKey: 'starter' | 'pro' | 'elite') => {
-  // TODO: Implémenter le tunnel d'abonnement
-  console.log(`subscribe to ${planKey}`)
+const subscribe = async (planKey: 'starter' | 'pro' | 'elite') => {
+  await redirectToCheckout(planKey)
 }
 
 const PlanCard: React.FC<{
@@ -50,14 +49,14 @@ const PlanCard: React.FC<{
             {icons[planKey]}
           </div>
           
-          <h3 className="text-2xl font-bold text-navy-900 mb-2">{plan.name}</h3>
+          <h3 className="text-2xl font-bold text-navy-900 dark:text-white mb-2">{plan.name}</h3>
           
           <div className="mb-4">
-            <span className="text-4xl font-bold text-navy-900">{plan.price}€</span>
-            <span className="text-gray-600">/mois</span>
+            <span className="text-4xl font-bold text-navy-900 dark:text-white">{plan.price}€</span>
+            <span className="text-gray-600 dark:text-gray-300">/mois</span>
           </div>
           
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-300">
             Commission: {(plan.commission * 100)}% par mission
           </p>
         </div>
@@ -66,7 +65,7 @@ const PlanCard: React.FC<{
           {plan.features.map((feature, i) => (
             <li key={i} className="flex items-start space-x-3">
               <Check className="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" />
-              <span className="text-gray-700">{feature}</span>
+              <span className="text-gray-700 dark:text-gray-300">{feature}</span>
             </li>
           ))}
         </ul>
@@ -86,7 +85,7 @@ const PlanCard: React.FC<{
 
 export const PricingSection: React.FC = () => {
   return (
-    <section id="pricing" className="py-20 bg-white">
+    <section id="pricing" className="py-20 bg-white dark:bg-navy-800">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <motion.div
           className="text-center mb-16"
@@ -95,10 +94,10 @@ export const PricingSection: React.FC = () => {
           transition={{ duration: 0.6 }}
           viewport={{ once: true }}
         >
-          <h2 className="text-3xl md:text-4xl font-bold text-navy-900 mb-4">
+          <h2 className="text-3xl md:text-4xl font-bold text-navy-900 dark:text-white mb-4">
             Choisissez votre plan
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
             Des tarifs transparents adaptés à tous les besoins. 
             Commissions dégressives et support premium inclus.
           </p>
@@ -131,23 +130,23 @@ export const PricingSection: React.FC = () => {
           transition={{ duration: 0.6, delay: 0.8 }}
           viewport={{ once: true }}
         >
-          <div className="bg-primary-50 rounded-2xl p-8">
-            <h3 className="text-xl font-semibold text-navy-900 mb-4">
+          <div className="bg-primary-50 dark:bg-navy-900 rounded-2xl p-8">
+            <h3 className="text-xl font-semibold text-navy-900 dark:text-white mb-4">
               Informations importantes
             </h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm text-gray-600">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-sm text-gray-600 dark:text-gray-300">
               <div>
-                <strong className="text-navy-900">Missions ponctuelles:</strong>
+                <strong className="text-navy-900 dark:text-white">Missions ponctuelles:</strong>
                 <br />
                 Minimum 150€ par projet
               </div>
               <div>
-                <strong className="text-navy-900">Rush (+10%):</strong>
+                <strong className="text-navy-900 dark:text-white">Rush (+10%):</strong>
                 <br />
                 Livraison en moins de 24h
               </div>
               <div>
-                <strong className="text-navy-900">Paiement:</strong>
+                <strong className="text-navy-900 dark:text-white">Paiement:</strong>
                 <br />
                 Système d'escrow sécurisé
               </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import { Mail, Phone, MapPin, Facebook, Twitter, Linkedin, Instagram } from 'luc
 
 export const Footer: React.FC = () => {
   return (
-    <footer className="bg-navy-900 text-white">
+    <footer className="bg-navy-900 text-white dark:bg-navy-950 dark:text-gray-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Logo et Description */}
@@ -11,21 +11,21 @@ export const Footer: React.FC = () => {
             <div className="flex items-center space-x-2 mb-4">
               <img src="/logo.svg" alt="GhostContent" className="h-8" />
             </div>
-            <p className="text-gray-300 mb-6 max-w-md">
+            <p className="text-gray-300 dark:text-gray-400 mb-6 max-w-md">
               La plateforme qui connecte les clients premium avec les meilleurs freelances créatifs.
               Ton contenu. Sans effort.
             </p>
             <div className="flex space-x-4">
-              <a href="#" className="text-gray-400 hover:text-gold-500 transition-colors">
+              <a href="#" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 transition-colors">
                 <Facebook className="w-5 h-5" />
               </a>
-              <a href="#" className="text-gray-400 hover:text-gold-500 transition-colors">
+              <a href="#" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 transition-colors">
                 <Twitter className="w-5 h-5" />
               </a>
-              <a href="#" className="text-gray-400 hover:text-gold-500 transition-colors">
+              <a href="#" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 transition-colors">
                 <Linkedin className="w-5 h-5" />
               </a>
-              <a href="#" className="text-gray-400 hover:text-gold-500 transition-colors">
+              <a href="#" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 transition-colors">
                 <Instagram className="w-5 h-5" />
               </a>
             </div>
@@ -35,11 +35,11 @@ export const Footer: React.FC = () => {
           <div>
             <h3 className="text-lg font-semibold mb-4">Liens Rapides</h3>
             <ul className="space-y-2">
-              <li><a href="#home" className="text-gray-300 hover:text-gold-500 transition-colors">Accueil</a></li>
-              <li><a href="#pricing" className="text-gray-300 hover:text-gold-500 transition-colors">Tarifs</a></li>
-              <li><a href="#how-it-works" className="text-gray-300 hover:text-gold-500 transition-colors">Comment ça marche</a></li>
-              <li><a href="#portfolio" className="text-gray-300 hover:text-gold-500 transition-colors">Portfolio</a></li>
-              <li><a href="#faq" className="text-gray-300 hover:text-gold-500 transition-colors">FAQ</a></li>
+              <li><a href="#home" className="text-gray-300 hover:text-gold-500 dark:text-gray-400 dark:hover:text-gold-400 transition-colors">Accueil</a></li>
+              <li><a href="#pricing" className="text-gray-300 hover:text-gold-500 dark:text-gray-400 dark:hover:text-gold-400 transition-colors">Tarifs</a></li>
+              <li><a href="#how-it-works" className="text-gray-300 hover:text-gold-500 dark:text-gray-400 dark:hover:text-gold-400 transition-colors">Comment ça marche</a></li>
+              <li><a href="#portfolio" className="text-gray-300 hover:text-gold-500 dark:text-gray-400 dark:hover:text-gold-400 transition-colors">Portfolio</a></li>
+              <li><a href="#faq" className="text-gray-300 hover:text-gold-500 dark:text-gray-400 dark:hover:text-gold-400 transition-colors">FAQ</a></li>
             </ul>
           </div>
 
@@ -49,30 +49,30 @@ export const Footer: React.FC = () => {
             <div className="space-y-3">
               <div className="flex items-center space-x-3">
                 <Mail className="w-5 h-5 text-gold-500" />
-                <span className="text-gray-300">hello@ghostcontent.fr</span>
+                <span className="text-gray-300 dark:text-gray-400">hello@ghostcontent.fr</span>
               </div>
               <div className="flex items-center space-x-3">
                 <Phone className="w-5 h-5 text-gold-500" />
-                <span className="text-gray-300">+33 1 23 45 67 89</span>
+                <span className="text-gray-300 dark:text-gray-400">+33 1 23 45 67 89</span>
               </div>
               <div className="flex items-center space-x-3">
                 <MapPin className="w-5 h-5 text-gold-500" />
-                <span className="text-gray-300">Paris, France</span>
+                <span className="text-gray-300 dark:text-gray-400">Paris, France</span>
               </div>
             </div>
           </div>
         </div>
 
         {/* Bottom Bar */}
-        <div className="border-t border-gray-700 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-gray-400 text-sm">
+        <div className="border-t border-gray-700 dark:border-gray-600 mt-8 pt-8 flex flex-col md:flex-row justify-between items-center">
+          <p className="text-gray-400 dark:text-gray-500 text-sm">
             © 2024 Ghost Content. Tous droits réservés.
           </p>
           <div className="flex space-x-6 mt-4 md:mt-0">
-            <a href="/privacy" className="text-gray-400 hover:text-gold-500 text-sm transition-colors">
+            <a href="/privacy" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 text-sm transition-colors">
               Politique de confidentialité
             </a>
-            <a href="/terms" className="text-gray-400 hover:text-gold-500 text-sm transition-colors">
+            <a href="/terms" className="text-gray-400 hover:text-gold-500 dark:text-gray-500 dark:hover:text-gold-400 text-sm transition-colors">
               Conditions d'utilisation
             </a>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Menu, X, User, LogOut } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { ThemeToggle } from '../ui/ThemeToggle'
 import { useAuth } from '../../hooks/useAuth'
 import { scrollToContact } from '../../lib/navigation'
 
@@ -20,7 +21,7 @@ export const Header: React.FC = () => {
 
   return (
     <motion.header
-      className="fixed top-0 w-full z-50 bg-white/80 backdrop-blur-md border-b border-white/20"
+      className="fixed top-0 w-full z-50 bg-white/80 dark:bg-navy-900/80 backdrop-blur-md border-b border-white/20 dark:border-navy-700"
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ duration: 0.5 }}
@@ -47,7 +48,7 @@ export const Header: React.FC = () => {
               <motion.a
                 key={item.name}
                 href={item.href}
-                className="text-navy-700 hover:text-gold-600 transition-colors duration-200"
+                className="text-navy-700 hover:text-gold-600 dark:text-gray-200 dark:hover:text-gold-500 transition-colors duration-200"
                 whileHover={{ scale: 1.05 }}
               >
                 {item.name}
@@ -57,17 +58,18 @@ export const Header: React.FC = () => {
 
           {/* User Actions */}
           <div className="hidden md:flex items-center space-x-4">
+            <ThemeToggle />
             {profile ? (
               <div className="flex items-center space-x-4">
                 <a
                   href={profile.user_type === 'client' ? '/dashboard/client' : '/dashboard/freelancer'}
-                  className="text-sm text-navy-700 hover:text-gold-600 transition-colors"
+                  className="text-sm text-navy-700 hover:text-gold-600 dark:text-gray-200 dark:hover:text-gold-500 transition-colors"
                 >
                   Dashboard
                 </a>
                 <div className="flex items-center space-x-2">
-                  <User className="w-5 h-5 text-navy-700" />
-                  <span className="text-sm text-navy-700">{profile.full_name || profile.email}</span>
+                  <User className="w-5 h-5 text-navy-700 dark:text-gray-200" />
+                  <span className="text-sm text-navy-700 dark:text-gray-200">{profile.full_name || profile.email}</span>
                   {profile.subscription_plan && (
                     <span className="px-2 py-1 text-xs bg-gold-100 text-gold-800 rounded-full capitalize">
                       {profile.subscription_plan}
@@ -76,7 +78,7 @@ export const Header: React.FC = () => {
                 </div>
                 <button
                   onClick={signOut}
-                  className="text-navy-700 hover:text-red-600 transition-colors"
+                  className="text-navy-700 hover:text-red-600 dark:text-gray-200 dark:hover:text-red-500 transition-colors"
                 >
                   <LogOut className="w-5 h-5" />
                 </button>
@@ -99,13 +101,13 @@ export const Header: React.FC = () => {
 
           {/* Menu Mobile */}
           <button
-            className="md:hidden p-2 rounded-lg hover:bg-gray-100 transition-colors"
+            className="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-navy-700 transition-colors"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           >
             {isMenuOpen ? (
-              <X className="w-6 h-6 text-navy-700" />
+              <X className="w-6 h-6 text-navy-700 dark:text-gray-200" />
             ) : (
-              <Menu className="w-6 h-6 text-navy-700" />
+              <Menu className="w-6 h-6 text-navy-700 dark:text-gray-200" />
             )}
           </button>
         </div>
@@ -113,29 +115,30 @@ export const Header: React.FC = () => {
         {/* Menu Mobile Dropdown */}
         {isMenuOpen && (
           <motion.div
-            className="md:hidden bg-white border-t border-gray-200"
+            className="md:hidden bg-white dark:bg-navy-900 border-t border-gray-200 dark:border-navy-700"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
           >
             <div className="px-4 py-6 space-y-4">
+              <ThemeToggle />
               {navigation.map((item) => (
                 <a
                   key={item.name}
                   href={item.href}
-                  className="block text-navy-700 hover:text-gold-600 transition-colors duration-200"
+                  className="block text-navy-700 hover:text-gold-600 dark:text-gray-200 dark:hover:text-gold-500 transition-colors duration-200"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {item.name}
                 </a>
               ))}
-              <div className="pt-4 border-t border-gray-200 space-y-3">
+              <div className="pt-4 border-t border-gray-200 dark:border-navy-700 space-y-3">
                 {profile ? (
                   <div className="space-y-2">
-                    <p className="text-sm font-medium text-navy-700">{profile.full_name || profile.email}</p>
+                    <p className="text-sm font-medium text-navy-700 dark:text-gray-200">{profile.full_name || profile.email}</p>
                     <a
                       href={profile.user_type === 'client' ? '/dashboard/client' : '/dashboard/freelancer'}
-                      className="block text-sm text-navy-700 hover:text-gold-600 transition-colors"
+                      className="block text-sm text-navy-700 hover:text-gold-600 dark:text-gray-200 dark:hover:text-gold-500 transition-colors"
                       onClick={() => setIsMenuOpen(false)}
                     >
                       Dashboard

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+export const ThemeToggle: React.FC = () => {
+  const prefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    return (localStorage.getItem('theme') as 'light' | 'dark') || (prefersDark ? 'dark' : 'light')
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return (
+    <button
+      aria-label="Basculer le thème"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-navy-700 transition-colors"
+    >
+      {theme === 'dark' ? <Sun className="w-5 h-5 text-yellow-400" /> : <Moon className="w-5 h-5 text-navy-700" />}
+    </button>
+  )
+}

--- a/src/components/widgets/ProjectList.tsx
+++ b/src/components/widgets/ProjectList.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+type Project = { id: string; name: string; status: string }
+
+export const ProjectList: React.FC<{ title: string; projects: Project[] }> = ({ title, projects }) => {
+  return (
+    <div className="bg-white dark:bg-navy-800 rounded-xl p-4 shadow">
+      <h3 className="text-lg font-semibold mb-2 text-navy-900 dark:text-white">{title}</h3>
+      {projects.length ? (
+        <ul className="space-y-2">
+          {projects.map((p) => (
+            <li key={p.id} className="flex justify-between text-sm text-gray-700 dark:text-gray-300">
+              <span>{p.name}</span>
+              <span className="capitalize">{p.status}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Aucun projet.</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/widgets/StatsWidget.tsx
+++ b/src/components/widgets/StatsWidget.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+type Stat = { label: string; value: string | number }
+
+export const StatsWidget: React.FC<{ stats: Stat[] }> = ({ stats }) => {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {stats.map((s) => (
+        <div key={s.label} className="bg-white dark:bg-navy-800 rounded-xl p-4 shadow">
+          <p className="text-sm text-gray-500 dark:text-gray-400">{s.label}</p>
+          <p className="text-2xl font-bold text-navy-900 dark:text-white">{s.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -66,3 +66,23 @@ export const subscriptionPlans = {
     ]
   }
 }
+
+export const redirectToCheckout = async (planKey: 'starter' | 'pro' | 'elite') => {
+  const stripe = await getStripe()
+  if (!stripe) return
+
+  try {
+    const res = await fetch('/api/create-checkout-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ priceId: subscriptionPlans[planKey].id })
+    })
+    const data = await res.json()
+    const { error } = await stripe.redirectToCheckout({ sessionId: data.id })
+    if (error) {
+      console.error('Stripe redirect error', error)
+    }
+  } catch (err) {
+    console.error('Checkout session error', err)
+  }
+}

--- a/src/pages/checkout/Cancel.tsx
+++ b/src/pages/checkout/Cancel.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const CheckoutCancel: React.FC = () => {
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-2xl font-bold text-navy-900 dark:text-white mb-4">Paiement annulé</h1>
+      <p className="text-gray-700 dark:text-gray-300 mb-6">Votre transaction n'a pas été finalisée.</p>
+      <a href="/" className="text-gold-600">Retour à l'accueil</a>
+    </div>
+  )
+}

--- a/src/pages/checkout/Success.tsx
+++ b/src/pages/checkout/Success.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react'
+import { useAuth } from '../../hooks/useAuth'
+import { supabase } from '../../lib/supabase'
+
+export const CheckoutSuccess: React.FC = () => {
+  const { profile } = useAuth()
+
+  useEffect(() => {
+    const update = async () => {
+      if (profile) {
+        await supabase.from('profiles').update({ subscription_active: true }).eq('id', profile.id)
+      }
+    }
+    update()
+  }, [profile])
+
+  return (
+    <div className="p-6 text-center">
+      <h1 className="text-2xl font-bold mb-4">Paiement confirmé</h1>
+      <p className="text-gray-700 dark:text-gray-300 mb-6">Merci pour votre abonnement.</p>
+      <a href="/" className="text-gold-600">Retour à l'accueil</a>
+    </div>
+  )
+}

--- a/src/pages/dashboard/ClientDashboard.tsx
+++ b/src/pages/dashboard/ClientDashboard.tsx
@@ -1,13 +1,41 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useAuth } from '../../hooks/useAuth'
+import { ProjectList } from '../../components/widgets/ProjectList'
+import { StatsWidget } from '../../components/widgets/StatsWidget'
+import { supabase } from '../../lib/supabase'
+import { Button } from '../../components/ui/Button'
 
 export const ClientDashboard: React.FC = () => {
   const { profile } = useAuth()
+  const [projects, setProjects] = useState<any[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from('projects')
+        .select('*')
+        .eq('client_id', profile?.id)
+        .limit(5)
+      if (data) setProjects(data)
+    }
+    load()
+  }, [profile])
+
+  const stats = [
+    { label: 'Projets', value: projects.length },
+    { label: 'Dépenses', value: '0€' }
+  ]
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Tableau de bord Client</h1>
-      <p className="text-gray-700">Bienvenue {profile?.full_name || profile?.email}</p>
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-navy-900 dark:text-white">Tableau de bord Client</h1>
+      <p className="text-gray-700 dark:text-gray-300">Bienvenue {profile?.full_name || profile?.email}</p>
+      <StatsWidget stats={stats} />
+      <ProjectList title="Projets en cours" projects={projects} />
+      <div>
+        <h3 className="text-lg font-semibold mb-2 text-navy-900 dark:text-white">Actions rapides</h3>
+        <Button>Créer un projet</Button>
+      </div>
     </div>
   )
 }

--- a/src/pages/dashboard/FreelancerDashboard.tsx
+++ b/src/pages/dashboard/FreelancerDashboard.tsx
@@ -1,13 +1,41 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useAuth } from '../../hooks/useAuth'
+import { ProjectList } from '../../components/widgets/ProjectList'
+import { StatsWidget } from '../../components/widgets/StatsWidget'
+import { supabase } from '../../lib/supabase'
+import { Button } from '../../components/ui/Button'
 
 export const FreelancerDashboard: React.FC = () => {
   const { profile } = useAuth()
+  const [projects, setProjects] = useState<any[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from('projects')
+        .select('*')
+        .eq('freelancer_id', profile?.id)
+        .limit(5)
+      if (data) setProjects(data)
+    }
+    load()
+  }, [profile])
+
+  const stats = [
+    { label: 'Missions', value: projects.length },
+    { label: 'Revenus', value: '0€' }
+  ]
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Tableau de bord Freelance</h1>
-      <p className="text-gray-700">Bienvenue {profile?.full_name || profile?.email}</p>
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold text-navy-900 dark:text-white">Tableau de bord Freelance</h1>
+      <p className="text-gray-700 dark:text-gray-300">Bienvenue {profile?.full_name || profile?.email}</p>
+      <StatsWidget stats={stats} />
+      <ProjectList title="Projets en cours" projects={projects} />
+      <div>
+        <h3 className="text-lg font-semibold mb-2 text-navy-900 dark:text-white">Actions rapides</h3>
+        <Button>Parcourir les missions</Button>
+      </div>
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode and add theme toggle
- integrate Stripe checkout flow with success/cancel pages
- animate contact, FAQ and portfolio sections
- expand dashboards with stats and project widgets

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a204f601b083259ae916c5f4274128